### PR TITLE
Enable IntelliJ to recognize generated classes

### DIFF
--- a/sbt-plugin/src/main/scala/ch/timo_schmid/sbt/i18n/I18nPlugin.scala
+++ b/sbt-plugin/src/main/scala/ch/timo_schmid/sbt/i18n/I18nPlugin.scala
@@ -30,7 +30,7 @@ object I18nPlugin extends AutoPlugin {
     i18nDirectory := baseDirectory.value / "src/main/i18n",
     i18nPackageName := "i18n",
     generateI18n := {
-      genI18n(i18nDirectory.value, sourceManaged.value, i18nPackageName.value)
+      genI18n(i18nDirectory.value, sourceManaged.value / "main", i18nPackageName.value)
     },
     sourceGenerators in Compile += generateI18n.taskValue
   )


### PR DESCRIPTION
We need to put the generated classes inside a `main` folder in
`target/scala-2.12/src_managed` so IntelliJ IDEA can find them.